### PR TITLE
Fix CurseForge links and spelling in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-# [![](http://cf.way2muchnoise.eu/full_subterranean-wilderness_downloads.svg)](https://minecraft.curseforge.com/projects/subterranean-wilderness) [![](http://cf.way2muchnoise.eu/versions/subterranean-wilderness.svg)](https://minecraft.curseforge.com/projects/subterranean-wilderness)
-![](https://i.imgur.com/bstH64b.png)
+# [![curseforge](http://cf.way2muchnoise.eu/full_subterranean-wilderness_downloads.svg)](https://www.curseforge.com/minecraft/mc-mods/subterranean-wilderness) [![files](http://cf.way2muchnoise.eu/versions/subterranean-wilderness.svg)](https://www.curseforge.com/minecraft/mc-mods/subterranean-wilderness/files)
 
-The source code for Subterranean Wilderness, a spiritual successor to WTF's CaveBiomes, completely rewritten and enchanced. Subterranean Wilderness aims to spice up the old vanilla caves you got bored of years ago and bring you the cave update you always wanted.
+![banner](https://i.imgur.com/bstH64b.png)
 
-Delve deep into the depths of the earth and unfold the beauty of its wild and untouched, diverse environments and climates. Throughout your journey, you will come across the frigid, pure and flawless exteriors of glacial caves; trudge through the impassable, ravishing flora of humid tropical caves; unearth the fascinating fungal kingdoms beneath mushroom islands; discover the many stunning vibrant corals flourishing in flooded sea caves, with many, many more still waiting to be explored..
+The source code for Subterranean Wilderness, a spiritual successor to WTF's CaveBiomes, completely rewritten and enhanced. Subterranean Wilderness aims to spice up the old vanilla caves you got bored of years ago and bring you the cave update you always wanted.
 
-## Links
-CurseForge: https://www.curseforge.com/minecraft/mc-mods/subterranean-wilderness  
+Delve deep into the depths of the earth and unfold the beauty of its wild, untouched and diverse environments and climates. Throughout your journey you will come across the frigid, pure and flawless exteriors of glacial caves; trudge through the impassable, ravishing flora of humid tropical caves; unearth the fascinating fungal kingdoms beneath mushroom islands; discover the many stunning vibrant corals flourishing in flooded sea caves, with many many more still waiting to be explored.
+
+## Download
+
+Subterranean Wilderness is available on [CurseForge](https://www.curseforge.com/minecraft/mc-mods/subterranean-wilderness).


### PR DESCRIPTION
This link doesn't work;
https://minecraft.curseforge.com/projects/subterranean-wilderness
I replaced it with the working one:
https://www.curseforge.com/minecraft/mc-mods/subterranean-wilderness